### PR TITLE
Add VTK build variant

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,7 +2,7 @@ cmake -G "Ninja" ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D BUILD_SHARED_LIBS=ON  ^
       -D "CMAKE_INSTALL_PREFIX=%PREFIX%" ^
-      -D USE_VTK=OFF ^
+      -D USE_VTK=%use_vtk% ^
       -D MMG5_PACKAGE:BOOL=OFF ^
       -S .  ^
       -B builddir

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,6 +4,7 @@ cmake -G "Ninja" ^
       -D "CMAKE_INSTALL_PREFIX=%PREFIX%" ^
       -D USE_VTK=%use_vtk% ^
       -D MMG5_PACKAGE:BOOL=OFF ^
+      -D "CMAKE_CXX_FLAGS=/DNOMINMAX" ^
       -S .  ^
       -B builddir
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ cmake -G "Ninja" \
     -DTEST_LIBMMG2D=OFF \
     -DTEST_LIBMMGS=OFF \
     -DTEST_LIBMMG=OFF \
-    -DUSE_VTK=OFF \
+    -DUSE_VTK=${use_vtk} \
     -DUSE_ELAS=ON \
     -S . \
     -B build

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+use_vtk:
+  - "OFF"
+  - "ON"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,13 +14,10 @@ source:
 
 build:
   number: 8
-  {% if use_vtk == "ON" %}
-  string: "vtk_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"
-  {% else %}
-  ignore_run_exports_from:
-    - {{ compiler('cxx') }}
-    - {{ compiler('c') }}
-  {% endif %}
+  string: "vtk_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [use_vtk == "ON"]
+  ignore_run_exports_from:   # [use_vtk != "ON"]
+    - {{ compiler('cxx') }}  # [use_vtk != "ON"]
+    - {{ compiler('c') }}    # [use_vtk != "ON"]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,14 @@ source:
     - patchs/0001-Add-Option-to-deactivate-the-CPack-directives.patch
 
 build:
-  number: 7
+  number: 8
+  {% if use_vtk == "ON" %}
+  string: "vtk_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"
+  {% else %}
   ignore_run_exports_from:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
+  {% endif %}
 
 requirements:
   build:
@@ -31,10 +35,12 @@ requirements:
     - libscotch              # [not win]
     - iscd-commons           # [not win]
     - iscd-linearelasticity  # [not win]
+    - vtk                    # [use_vtk == "ON"]
   run:
     - libscotch              # [not win]
     - iscd-commons           # [not win]
     - iscd-linearelasticity  # [not win]
+    - vtk                    # [use_vtk == "ON"]
 
 test:
   commands:


### PR DESCRIPTION
## Summary

Add a build variant that compiles MMG with VTK support (`-DUSE_VTK=ON`). This produces a second package alongside the existing non-VTK build, enabling downstream packages that need MMG's VTK I/O functions (`MMG3D_loadVtkMesh`, `MMGS_loadVtkMesh`, etc.).

## Changes

- **`recipe/conda_build_config.yaml`** (new): defines `use_vtk` variant with values `"OFF"` and `"ON"`
- **`recipe/meta.yaml`**:
  - Bump build number to 8
  - Add custom build string `vtk_h<hash>_<buildnum>` when `use_vtk == "ON"` so the two variants are distinguishable
  - Add `vtk` to host/run dependencies when `use_vtk == "ON"`
  - Keep `ignore_run_exports_from` only for the non-VTK build (pure C — no C++ runtime needed), remove it for the VTK variant (links against C++ VTK libraries)
- **`recipe/build.sh`**: pass `-DUSE_VTK=${use_vtk}` instead of hardcoded `-DUSE_VTK=OFF`
- **`recipe/bld.bat`**: pass `-D USE_VTK=%use_vtk%` instead of hardcoded `-D USE_VTK=OFF`

## Build string

The custom build string distinguishes the two variants in the same channel:

```
mmgsuite-5.8.0-h1234567_8         # use_vtk=OFF (default build string)
mmgsuite-5.8.0-vtk_h1234567_8    # use_vtk=ON  (custom build string)
```

Downstream packages can depend on the VTK variant using:

```yaml
requirements:
  host:
    - mmgsuite *=vtk*
  run:
    - mmgsuite *=vtk*
```