### PR TITLE
Add osx-arm64 (Apple Silicon) support

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,10 @@
 github:
   branch_name: main
   tooling_branch_name: main
+build_platform:
+  osx_arm64: osx_64
+provider:
+  osx_arm64: default
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,11 @@
 set -e
+
+if [[ "$(uname -m)" == "arm64" ]]; then
+  USE_ELAS=OFF
+else
+  USE_ELAS=ON
+fi
+
 cmake -G "Ninja" \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
@@ -8,7 +15,7 @@ cmake -G "Ninja" \
     -DTEST_LIBMMGS=OFF \
     -DTEST_LIBMMG=OFF \
     -DUSE_VTK=${use_vtk} \
-    -DUSE_ELAS=ON \
+    -DUSE_ELAS=${USE_ELAS} \
     -S . \
     -B build
 cmake --build ./build --verbose --config Release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patchs/0001-Add-Option-to-deactivate-the-CPack-directives.patch
 
 build:
-  number: 9
+  number: 10
   string: "vtk_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [use_vtk == "ON"]
   ignore_run_exports_from:   # [use_vtk != "ON"]
     - {{ compiler('cxx') }}  # [use_vtk != "ON"]
@@ -30,13 +30,13 @@ requirements:
     - cmake
     - ninja
     - libscotch              # [not win]
-    - iscd-commons           # [not win]
-    - iscd-linearelasticity  # [not win]
+    - iscd-commons           # [not win and not arm64]
+    - iscd-linearelasticity  # [not win and not arm64]
     - vtk                    # [use_vtk == "ON"]
   run:
     - libscotch              # [not win]
-    - iscd-commons           # [not win]
-    - iscd-linearelasticity  # [not win]
+    - iscd-commons           # [not win and not arm64]
+    - iscd-linearelasticity  # [not win and not arm64]
     - vtk                    # [use_vtk == "ON"]
 
 test:


### PR DESCRIPTION
This adds osx-arm64 builds for mmgsuite.

The only difference from the existing osx-64 build is that the ISCD elasticity module (`USE_ELAS`) is disabled on arm64 because `iscd-commons` and `iscd-linearelasticity` are not yet available on osx-arm64 on conda-forge. Core MMG remeshing functionality (mmg2d, mmg3d, mmgs) is unaffected.

Changes:
- `conda-forge.yml`: enable osx-arm64 cross-compilation from osx-64
- `recipe/meta.yaml`: skip iscd dependencies on arm64, bump build number
- `recipe/build.sh`: set `USE_ELAS=OFF` on arm64

If/when iscd-commons and iscd-linearelasticity gain osx-arm64 packages, the arm64 exclusion can be removed to restore full feature parity.