### PR TITLE
Rerender to generate osx-arm64 CI configs

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -16,6 +16,14 @@ jobs:
         CONFIG: osx_64_use_vtkON
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+      osx_arm64_use_vtkOFF:
+        CONFIG: osx_arm64_use_vtkOFF
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+      osx_arm64_use_vtkON:
+        CONFIG: osx_arm64_use_vtkON
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/osx_arm64_use_vtkOFF.yaml
+++ b/.ci_support/osx_arm64_use_vtkOFF.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libscotch:
+- 7.0.11
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+use_vtk:
+- 'OFF'
+vtk:
+- 9.6.0
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_use_vtkON.yaml
+++ b/.ci_support/osx_arm64_use_vtkON.yaml
@@ -1,0 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libscotch:
+- 7.0.11
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+use_vtk:
+- 'ON'
+vtk:
+- 9.6.0
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_use_vtkOFF</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18967&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mmgsuite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_use_vtkOFF" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_use_vtkON</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18967&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mmgsuite-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_use_vtkON" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_use_vtkOFF</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18967&branchName=main">

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 set -e
 
-if [[ "$(uname -m)" == "arm64" ]]; then
+if [[ "${target_platform}" == "osx-arm64" ]]; then
   USE_ELAS=OFF
 else
   USE_ELAS=ON

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,8 +2,12 @@ set -e
 
 if [[ "${target_platform}" == "osx-arm64" ]]; then
   USE_ELAS=OFF
+  # Disable Perl to skip Fortran header generation during cross-compilation.
+  # The genheader tool would be compiled for arm64 but needs to run on x86_64.
+  CROSS_ARGS="-DCMAKE_DISABLE_FIND_PACKAGE_Perl=TRUE"
 else
   USE_ELAS=ON
+  CROSS_ARGS=""
 fi
 
 cmake -G "Ninja" \
@@ -16,6 +20,7 @@ cmake -G "Ninja" \
     -DTEST_LIBMMG=OFF \
     -DUSE_VTK=${use_vtk} \
     -DUSE_ELAS=${USE_ELAS} \
+    ${CROSS_ARGS} \
     -S . \
     -B build
 cmake --build ./build --verbose --config Release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - test -f $PREFIX/lib/libmmg.so  # [linux]
     - test -f $PREFIX/lib/libmmg.dylib  # [osx]
     - test -f $PREFIX/include/mmg/libmmg.h  # [not win]
-    - test -f $PREFIX/include/mmg/libmmgf.h  # [not win]
+    - test -f $PREFIX/include/mmg/libmmgf.h  # [not win and not arm64]
 
 about:
   home: https://www.mmgtools.org/mmg-open-source-consortium

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,13 +30,13 @@ requirements:
     - setuptools-scm
   host:
     - libscotch              # [not win]
-    - iscd-commons           # [not win and not arm64]
-    - iscd-linearelasticity  # [not win and not arm64]
+    - iscd-commons           # [not win]
+    - iscd-linearelasticity  # [not win]
     - vtk                    # [use_vtk == "ON"]
   run:
     - libscotch              # [not win]
-    - iscd-commons           # [not win and not arm64]
-    - iscd-linearelasticity  # [not win and not arm64]
+    - iscd-commons           # [not win]
+    - iscd-linearelasticity  # [not win]
     - vtk                    # [use_vtk == "ON"]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,11 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
-  host:
-    - git
-    - setuptools-scm
     - cmake
     - ninja
+    - git
+    - setuptools-scm
+  host:
     - libscotch              # [not win]
     - iscd-commons           # [not win and not arm64]
     - iscd-linearelasticity  # [not win and not arm64]


### PR DESCRIPTION
## Summary

Fix osx-arm64 cross-compilation and generate missing CI configs.

### Manual changes

- **`recipe/meta.yaml`**: Move `cmake`, `ninja`, `git`, `setuptools-scm` from `host` to `build` requirements — build tools must run on the build host (x86_64), not the target (arm64) during cross-compilation
- **`recipe/build.sh`**: Use `$target_platform` instead of `uname -m` for arm64 detection — `uname -m` reports the build host architecture during cross-compilation
- **`recipe/build.sh`**: Disable Perl detection (`CMAKE_DISABLE_FIND_PACKAGE_Perl`) on osx-arm64 to skip Fortran header generation — MMG's `genheader` tool gets compiled for the target arch but needs to run on the build host

### Auto-generated changes

The rest of the diff (`.ci_support/`, `.scripts/`, `.azure-pipelines/`) was generated by conda-smithy rerender to add osx-arm64 CI configurations.

@conda-forge-admin, please rerender